### PR TITLE
Replace Poison with Jason [WIP]

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,6 +27,9 @@ config :jumubase, JumubaseWeb.Endpoint,
   pubsub: [name: Jumubase.PubSub,
            adapter: Phoenix.PubSub.PG2]
 
+# Use Jason for JSON parsing
+config :phoenix, :json_library, Jason
+
 # Keep microsecond precision in timestamps
 config :jumubase, Jumubase.Repo,
   migration_timestamps: [type: :naive_datetime_usec]

--- a/lib/jumubase_web/endpoint.ex
+++ b/lib/jumubase_web/endpoint.ex
@@ -27,7 +27,7 @@ defmodule JumubaseWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison
+    json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride
   plug Plug.Head

--- a/lib/jumubase_web/views/encoders/ecto_encoders.ex
+++ b/lib/jumubase_web/views/encoders/ecto_encoders.ex
@@ -1,18 +1,29 @@
-# The following Poison.Encoder implementations ensure that JSON-encoding an
+# The following Jason.Encoder implementations ensure that JSON-encoding an
 # Ecto changeset or record doesn't result in errors because of un-encodable
 # constructs (such as keyword lists).
 
-defimpl Poison.Encoder, for: Ecto.Changeset do
+require Protocol
+alias Jumubase.Showtime.{Appearance, Participant, Performance, Piece}
+
+# White-list schema fields that may be exposed via JSON
+Protocol.derive(Jason.Encoder, Performance, only: [:id, :contest_category_id, :appearances, :pieces])
+Protocol.derive(Jason.Encoder, Appearance, only: [:id, :instrument, :role, :participant])
+Protocol.derive(Jason.Encoder, Participant, only: [:id, :given_name, :family_name, :birthdate, :phone, :email])
+Protocol.derive(Jason.Encoder, Piece, only: [:id, :title, :composer, :composer_born, :composer_died, :artist, :epoch, :minutes, :seconds])
+
+defimpl Jason.Encoder, for: Ecto.Changeset do
   import JumubaseWeb.ErrorHelpers, only: [translate_error: 1]
 
-  def encode(changeset, options) do
+  def encode(changeset, _options) do
+    data = if changeset.action == :insert, do: %{}, else: changeset.data
+
     output = %{
-      data: changeset.data,
+      data: data,
       changes: changeset.changes,
       errors: get_errors(changeset),
       valid: changeset.valid?
     }
-    Poison.encode!(output, options)
+    Jason.encode!(output)
   end
 
   # Omit errors if changeset has no action (typically before first submission)
@@ -22,14 +33,8 @@ defimpl Poison.Encoder, for: Ecto.Changeset do
   end
 end
 
-defimpl Poison.Encoder, for: Ecto.Schema.Metadata do
-  def encode(_metadata, _options) do
-    Poison.encode!(nil)
-  end
-end
-
-defimpl Poison.Encoder, for: Ecto.Association.NotLoaded do
-  def encode(_metadata, _options) do
-    Poison.encode!(nil)
+defimpl Jason.Encoder, for: [MapSet, Range, Stream] do
+  def encode(struct, opts) do
+    Jason.Encode.list(Enum.to_list(struct), opts)
   end
 end

--- a/lib/jumubase_web/views/helpers/json_helpers.ex
+++ b/lib/jumubase_web/views/helpers/json_helpers.ex
@@ -7,7 +7,7 @@ defmodule JumubaseWeb.JsonHelpers do
   """
   def render_html_safe_json(value) do
     value
-    |> Poison.encode!()
+    |> Jason.encode!()
     |> String.replace("<", "\\u003c")
     |> String.replace(">", "\\u003e")
     |> raw()


### PR DESCRIPTION
Since Jason requires an explicit `@derive` where we specify which fields will be encoded, my initial idea was to whitelist the fields in one place (the `ecto_encoders.ex` file) instead of spread around schema files.

However, a much nicer solution would be to write a function that takes in a `%Performance{}` struct and recursively

* removes Ecto.Association.NotLoaded fields (or at least set them to nil)
* removes __struct__ and __meta__ fields
* removes "private" fields that aren't needed to populate the registration form

Unfortunately, I can't figure out how to write such a filter since Elixir structs don't implement the Enumerable protocol 😕