### PR TITLE
LW registration

### DIFF
--- a/assets/js/views/registration/form_field_error.js
+++ b/assets/js/views/registration/form_field_error.js
@@ -5,7 +5,7 @@ Vue.component('form-field-error', {
 
   template: `
     <div v-if="errors" class="has-error">
-      <small v-for="error in errors" class="help-block text-danger">
+      <small v-for="error in errors" class="help-block">
         {{error}}
       </small>
     </div>

--- a/lib/jumubase/foundation/contest.ex
+++ b/lib/jumubase/foundation/contest.ex
@@ -14,6 +14,7 @@ defmodule Jumubase.Foundation.Contest do
     field :start_date, :date
     field :end_date, :date
     field :certificate_date, :date
+    field :allows_registration, :boolean, read_after_writes: true
     field :timetables_public, :boolean, read_after_writes: true
 
     belongs_to :host, Host
@@ -23,7 +24,7 @@ defmodule Jumubase.Foundation.Contest do
   end
 
   @required_attrs [:season, :round, :host_id, :grouping, :deadline, :start_date, :end_date]
-  @optional_attrs [:certificate_date, :timetables_public]
+  @optional_attrs [:certificate_date, :allows_registration, :timetables_public]
 
   @doc false
   def changeset(%Contest{} = contest, attrs) do

--- a/lib/jumubase/foundation/foundation.ex
+++ b/lib/jumubase/foundation/foundation.ex
@@ -169,9 +169,9 @@ defmodule Jumubase.Foundation do
   Returns the next-round contest that advancing performances go to,
   or nil if no such contest exists.
   """
-  def get_successor(%Contest{season: season, round: 1}) do
+  def get_successor(%Contest{season: season, round: 1, grouping: grouping}) do
     Contest
-    |> where(season: ^season, round: 2)
+    |> where(season: ^season, round: 2, grouping: ^grouping)
     |> preload(:host)
     |> Repo.one()
   end

--- a/lib/jumubase/foundation/foundation.ex
+++ b/lib/jumubase/foundation/foundation.ex
@@ -31,11 +31,11 @@ defmodule Jumubase.Foundation do
     Repo.all(query)
   end
 
-  def list_predecessor_hosts(%Contest{round: 2, season: season}) do
+  def list_predecessor_hosts(%Contest{season: season, round: 2, grouping: grouping}) do
     query =
       from h in Host,
         join: c in assoc(h, :contests),
-        where: c.season == ^season and c.round == 1,
+        where: c.season == ^season and c.round == 1 and c.grouping == ^grouping,
         order_by: h.name,
         distinct: true
 

--- a/lib/jumubase/foundation/foundation.ex
+++ b/lib/jumubase/foundation/foundation.ex
@@ -82,7 +82,8 @@ defmodule Jumubase.Foundation do
     query =
       from c in Contest,
         where: c.round == ^round,
-        # uses UTC
+        where: c.allows_registration,
+        # We don't currently consider host time zone in deadline check:
         where: c.deadline >= ^Timex.today(),
         join: h in assoc(c, :host),
         order_by: h.name,

--- a/lib/jumubase/seeder.ex
+++ b/lib/jumubase/seeder.ex
@@ -96,14 +96,17 @@ defmodule Jumubase.Seeder do
     {:ok, deadline} = Date.new(year - 1, 12, 15)
 
     for host <- hosts do
+      grouping = host.current_grouping
+
       Factory.insert(:contest,
         host: host,
         season: season,
         round: round,
-        grouping: host.current_grouping,
+        grouping: grouping,
         start_date: start_date,
         end_date: end_date,
         deadline: deadline,
+        allows_registration: grouping != "2",
         contest_categories: ccs
       )
     end

--- a/lib/jumubase/showtime/showtime.ex
+++ b/lib/jumubase/showtime/showtime.ex
@@ -181,7 +181,7 @@ defmodule Jumubase.Showtime do
   def build_performance(%Contest{round: _}), do: %Performance{}
 
   def create_performance(%Contest{} = contest, attrs \\ %{}) do
-    Performance.changeset(%Performance{}, attrs)
+    Performance.changeset(%Performance{}, attrs, contest.round)
     |> stitch_participants
     |> put_age_groups(contest)
     |> attempt_insert(contest.round)
@@ -192,7 +192,7 @@ defmodule Jumubase.Showtime do
       {:error, :has_results}
     else
       performance
-      |> Performance.changeset(attrs)
+      |> Performance.changeset(attrs, contest.round)
       |> stitch_participants
       |> put_age_groups(contest)
       |> Repo.update()
@@ -202,7 +202,7 @@ defmodule Jumubase.Showtime do
   def change_performance(%Performance{} = performance) do
     performance
     |> Repo.preload([:appearances, :pieces])
-    |> Performance.changeset(%{})
+    |> change()
   end
 
   def delete_performance!(%Performance{} = performance) do

--- a/lib/jumubase_web/controllers/page_controller.ex
+++ b/lib/jumubase_web/controllers/page_controller.ex
@@ -11,11 +11,14 @@ defmodule JumubaseWeb.PageController do
 
   def registration(conn, _params) do
     rw_contests = Foundation.list_open_contests(1)
+    lw_contests = Foundation.list_open_contests(2)
+    jumu_contests = rw_contests ++ lw_contests
     kimu_contests = Foundation.list_open_contests(0)
-    general_deadline = Foundation.general_deadline(rw_contests ++ kimu_contests)
+
+    general_deadline = Foundation.general_deadline(jumu_contests ++ kimu_contests)
 
     conn
-    |> assign(:rw_contests, rw_contests)
+    |> assign(:jumu_contests, jumu_contests)
     |> assign(:kimu_contests, kimu_contests)
     |> assign(:general_deadline, general_deadline)
     |> render("registration.html")

--- a/lib/jumubase_web/controllers/performance_controller.ex
+++ b/lib/jumubase_web/controllers/performance_controller.ex
@@ -7,8 +7,8 @@ defmodule JumubaseWeb.PerformanceController do
   alias Jumubase.Showtime
   alias JumubaseWeb.Email
 
-  # Check deadline of nested contest and pass it to all actions
-  def action(conn, _), do: contest_deadline_check_action(conn, __MODULE__)
+  # Check that nested contest is open, then pass it to all actions
+  def action(conn, _), do: contest_openness_check_action(conn, __MODULE__)
 
   def new(conn, _params, contest) do
     changeset =

--- a/lib/jumubase_web/templates/internal/contest/edit.html.eex
+++ b/lib/jumubase_web/templates/internal/contest/edit.html.eex
@@ -70,6 +70,12 @@
   </div>
 
   <div class="checkbox">
+    <%= label f, :allows_registration do %>
+      <%= checkbox f, :allows_registration %> <%= gettext("Allows registration") %>
+    <% end %>
+  </div>
+
+  <div class="checkbox">
     <%= label f, :timetables_public do %>
       <%= checkbox f, :timetables_public %> <%= gettext("Timetables public") %>
     <% end %>

--- a/lib/jumubase_web/templates/internal/performance/edit.html.eex
+++ b/lib/jumubase_web/templates/internal/performance/edit.html.eex
@@ -10,5 +10,6 @@
   conn: @conn,
   path: Routes.internal_contest_performance_path(@conn, :update, @contest, @performance),
   changeset: @changeset,
+  predecessor_host_options: predecessor_host_options(@contest),
   submit_title: gettext("Save Changes")
   %>

--- a/lib/jumubase_web/templates/internal/performance/new.html.eex
+++ b/lib/jumubase_web/templates/internal/performance/new.html.eex
@@ -10,5 +10,6 @@
   conn: @conn,
   path: Routes.internal_contest_performance_path(@conn, :create, @contest),
   changeset: @changeset,
+  predecessor_host_options: predecessor_host_options(@contest),
   submit_title: gettext("Create Performance")
   %>

--- a/lib/jumubase_web/templates/page/registration.html.eex
+++ b/lib/jumubase_web/templates/page/registration.html.eex
@@ -20,7 +20,7 @@
         <h3><%= gettext("Jumu") %></h3>
         <%= render "_contest_list.html",
           conn: @conn,
-          contests: @rw_contests,
+          contests: @jumu_contests,
           general_deadline: @general_deadline
           %>
       </div>

--- a/lib/jumubase_web/templates/performance/_form.html.eex
+++ b/lib/jumubase_web/templates/performance/_form.html.eex
@@ -1,7 +1,18 @@
 <div class="row">
   <div id="registration-form" v-cloak class="col-lg-9">
-    <%= form_for @changeset, @path, [novalidate: true], fn _ -> %>
+    <%= form_for @changeset, @path, [novalidate: true], fn f -> %>
       <%= render "_form_error_summary.html" %>
+
+      <%= if !Enum.empty?(@predecessor_host_options) do %>
+        <div class="row">
+          <div class="form-group col-md-5">
+            <%= label f, :predecessor_host_id, gettext("First round"), class: "control-label" %>
+            <%= select f, :predecessor_host_id, @predecessor_host_options,
+              prompt: gettext("Please choose"), class: "form-control" %>
+            <%= error_tag f, :predecessor_host_id %>
+          </div>
+        </div>
+      <% end %>
 
       <div class="row">
         <div class="form-group col-md-5">

--- a/lib/jumubase_web/templates/performance/_form.html.eex
+++ b/lib/jumubase_web/templates/performance/_form.html.eex
@@ -5,7 +5,7 @@
 
       <%= if !Enum.empty?(@predecessor_host_options) do %>
         <div class="row">
-          <div class="form-group col-md-5">
+          <div class="form-group col-md-5 <%= if f.errors[:predecessor_host_id], do: "has-error" %>">
             <%= label f, :predecessor_host_id, gettext("First round"), class: "control-label" %>
             <%= select f, :predecessor_host_id, @predecessor_host_options,
               prompt: gettext("Please choose"), class: "form-control" %>

--- a/lib/jumubase_web/templates/performance/edit.html.eex
+++ b/lib/jumubase_web/templates/performance/edit.html.eex
@@ -10,5 +10,6 @@
   conn: @conn,
   path: Routes.performance_path(@conn, :update, @contest, @performance, edit_code: @performance.edit_code),
   changeset: @changeset,
+  predecessor_host_options: predecessor_host_options(@contest),
   submit_title: gettext("Save Changes")
   %>

--- a/lib/jumubase_web/templates/performance/new.html.eex
+++ b/lib/jumubase_web/templates/performance/new.html.eex
@@ -11,5 +11,6 @@
   path: Routes.performance_path(@conn, :create, @contest),
   kimu_path: registration_path(@conn, @kimu_contest),
   changeset: @changeset,
+  predecessor_host_options: predecessor_host_options(@contest),
   submit_title: [gettext("Submit registration"), " ", icon_tag("send")]
   %>

--- a/lib/jumubase_web/views/internal/performance_view.ex
+++ b/lib/jumubase_web/views/internal/performance_view.ex
@@ -13,6 +13,7 @@ defmodule JumubaseWeb.Internal.PerformanceView do
       prize: 2
     ]
 
+  import JumubaseWeb.PerformanceView, only: [predecessor_host_options: 1]
   import JumubaseWeb.Internal.CategoryView, only: [genre_name: 1]
   import JumubaseWeb.Internal.ContestView, only: [name: 1, name_with_flag: 1]
   import JumubaseWeb.Internal.HostView, only: [flag: 1]

--- a/lib/jumubase_web/views/performance_view.ex
+++ b/lib/jumubase_web/views/performance_view.ex
@@ -36,6 +36,16 @@ defmodule JumubaseWeb.PerformanceView do
     |> raw
   end
 
+  @doc """
+  Returns predecessor host options based on the contest, suitable for a performance form.
+  """
+  def predecessor_host_options(%Contest{round: 2, grouping: grouping}) do
+    Foundation.list_hosts_by_grouping(grouping)
+    |> Enum.map(&{&1.name, &1.id})
+  end
+
+  def predecessor_host_options(%Contest{}), do: []
+
   # Private helpers
 
   defp render_registration_script(assigns) do

--- a/priv/gettext/auth.pot
+++ b/priv/gettext/auth.pot
@@ -36,7 +36,7 @@ msgid "You are now logged out."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/authorize.ex:173
+#: lib/jumubase_web/controllers/authorize.ex:183
 msgid "You need to log in to view this page."
 msgstr ""
 

--- a/priv/gettext/de/LC_MESSAGES/auth.po
+++ b/priv/gettext/de/LC_MESSAGES/auth.po
@@ -37,7 +37,7 @@ msgid "You are now logged out."
 msgstr "Du bist jetzt ausgeloggt."
 
 #, elixir-format
-#: lib/jumubase_web/controllers/authorize.ex:173
+#: lib/jumubase_web/controllers/authorize.ex:183
 msgid "You need to log in to view this page."
 msgstr "Du musst dich einloggen, um diese Seite zu besuchen."
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -85,16 +85,16 @@ msgstr "Neuer Benutzer"
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:24
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:35 lib/jumubase_web/templates/internal/category/_form.html.eex:46
 #: lib/jumubase_web/templates/internal/user/form.html.eex:42 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:139
-#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:22
-#: lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
+#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:13
+#: lib/jumubase_web/templates/performance/_form.html.eex:35 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
 msgid "Please choose"
 msgstr "Bitte wählen"
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/category/edit.html.eex:9
 #: lib/jumubase_web/templates/internal/contest/edit.html.eex:87 lib/jumubase_web/templates/internal/host/edit.html.eex:8
-#: lib/jumubase_web/templates/internal/performance/edit.html.eex:13 lib/jumubase_web/templates/internal/user/edit.html.eex:10
-#: lib/jumubase_web/templates/performance/edit.html.eex:13
+#: lib/jumubase_web/templates/internal/performance/edit.html.eex:14 lib/jumubase_web/templates/internal/user/edit.html.eex:10
+#: lib/jumubase_web/templates/performance/edit.html.eex:14
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
@@ -206,7 +206,7 @@ msgstr "Zeitzone"
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:67
-#: lib/jumubase_web/views/performance_view.ex:114
+#: lib/jumubase_web/views/performance_view.ex:121
 msgid "Accompanist"
 msgstr "Begleiter"
 
@@ -221,13 +221,13 @@ msgstr "Geburtsdatum"
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
-#: lib/jumubase_web/templates/performance/_form.html.eex:9 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
+#: lib/jumubase_web/templates/performance/_form.html.eex:22 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
 msgstr "Kategorie"
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:66
-#: lib/jumubase_web/views/performance_view.ex:115
+#: lib/jumubase_web/views/performance_view.ex:122
 msgid "Ensemblist"
 msgstr "Ensemblepartner"
 
@@ -266,7 +266,7 @@ msgid "Phone"
 msgstr "Telefon"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:48
+#: lib/jumubase_web/templates/performance/_form.html.eex:61
 msgid "Pieces"
 msgstr "Vorspielprogramm"
 
@@ -289,17 +289,17 @@ msgstr "Rolle"
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:65
-#: lib/jumubase_web/views/performance_view.ex:113
+#: lib/jumubase_web/views/performance_view.ex:120
 msgid "Soloist"
 msgstr "Solist"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:45
+#: lib/jumubase_web/templates/performance/_form.html.eex:58
 msgid "Add participant"
 msgstr "Teilnehmer hinzufügen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:55
+#: lib/jumubase_web/templates/performance/_form.html.eex:68
 msgid "Add piece"
 msgstr "Stück hinzufügen"
 
@@ -392,7 +392,7 @@ msgid "Programme"
 msgstr "Vorspielprogramm"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/new.html.eex:14
+#: lib/jumubase_web/templates/performance/new.html.eex:15
 msgid "Submit registration"
 msgstr "Anmeldung absenden"
 
@@ -758,12 +758,12 @@ msgstr "Vor der Wertung"
 
 #, elixir-format
 #: lib/jumubase_web/templates/page/contact.html.eex:60
-#: lib/jumubase_web/templates/performance/_form.html.eex:63
+#: lib/jumubase_web/templates/performance/_form.html.eex:76
 msgid "privacy policy"
 msgstr "Datenschutzerklärung"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:62
+#: lib/jumubase_web/templates/performance/_form.html.eex:75
 msgid "The data you enter will be handled as described in the"
 msgstr "Wie wir deine Angaben verarbeiten, steht in der"
 
@@ -823,7 +823,7 @@ msgid "Show categories"
 msgstr "Kategorien anzeigen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:33
+#: lib/jumubase_web/templates/performance/_form.html.eex:46
 msgid "Who takes part?"
 msgstr "Wer nimmt teil?"
 
@@ -879,7 +879,7 @@ msgid "Show participants"
 msgstr "Teilnehmer anzeigen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:37
+#: lib/jumubase_web/templates/performance/_form.html.eex:50
 msgid "Non-competing accompanists don’t need to register."
 msgstr "Begleiter ohne Wertung müssen nicht angemeldet werden."
 
@@ -924,14 +924,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr "Bitte fülle nur sichtbare Felder im Kontaktformular aus."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:253
+#: lib/jumubase_web/views/internal/performance_view.ex:255
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] "%{count} Vorspiel"
 msgstr[1] "%{count} Vorspiele"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:259
+#: lib/jumubase_web/views/internal/performance_view.ex:261
 msgid "Filter active"
 msgstr "Filter aktiv"
 
@@ -1406,14 +1406,14 @@ msgid "Publish results"
 msgstr "Ergebnisse freigeben"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:115
-#: lib/jumubase_web/views/internal/performance_view.ex:165
+#: lib/jumubase_web/views/internal/performance_view.ex:117
+#: lib/jumubase_web/views/internal/performance_view.ex:167
 msgid "No"
 msgstr "Nein"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:118
-#: lib/jumubase_web/views/internal/performance_view.ex:161
+#: lib/jumubase_web/views/internal/performance_view.ex:120
+#: lib/jumubase_web/views/internal/performance_view.ex:163
 msgid "Yes"
 msgstr "Ja"
 
@@ -1475,17 +1475,17 @@ msgid "Print certificates"
 msgstr "Urkunden ausgeben"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:203
+#: lib/jumubase_web/views/internal/performance_view.ex:205
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr "Tipp: Um ein eigenes Kimu-Logo hinzuzufügen, lege das bereits mit dem Logo bedruckte Papier erneut ein."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:209
+#: lib/jumubase_web/views/internal/performance_view.ex:211
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr "Die Ausgabe passt zum offiziellen Jumu-Urkundenpapier, welches du %{link} bestellen kannst."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:211
+#: lib/jumubase_web/views/internal/performance_view.ex:213
 msgid "here"
 msgstr "hier"
 
@@ -1817,3 +1817,8 @@ msgstr "Tabla"
 #: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
 msgid "Allows registration"
 msgstr "Neuanmeldung erlaubt"
+
+#, elixir-format
+#: lib/jumubase_web/templates/performance/_form.html.eex:11
+msgid "First round"
+msgstr "Regionalwettbewerb"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -85,8 +85,8 @@ msgstr "Neuer Benutzer"
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:24
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:35 lib/jumubase_web/templates/internal/category/_form.html.eex:46
 #: lib/jumubase_web/templates/internal/user/form.html.eex:42 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:139
-#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:13
-#: lib/jumubase_web/templates/performance/_form.html.eex:35 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
+#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:11
+#: lib/jumubase_web/templates/performance/_form.html.eex:33 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
 msgid "Please choose"
 msgstr "Bitte wählen"
 
@@ -205,8 +205,8 @@ msgid "Time zone"
 msgstr "Zeitzone"
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:67
-#: lib/jumubase_web/views/performance_view.ex:121
+#: lib/jumubase_web/views/performance_view.ex:77
+#: lib/jumubase_web/views/performance_view.ex:124
 msgid "Accompanist"
 msgstr "Begleiter"
 
@@ -221,13 +221,13 @@ msgstr "Geburtsdatum"
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
-#: lib/jumubase_web/templates/performance/_form.html.eex:22 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
+#: lib/jumubase_web/templates/performance/_form.html.eex:20 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
 msgstr "Kategorie"
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:66
-#: lib/jumubase_web/views/performance_view.ex:122
+#: lib/jumubase_web/views/performance_view.ex:76
+#: lib/jumubase_web/views/performance_view.ex:125
 msgid "Ensemblist"
 msgstr "Ensemblepartner"
 
@@ -266,7 +266,7 @@ msgid "Phone"
 msgstr "Telefon"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:61
+#: lib/jumubase_web/templates/performance/_form.html.eex:59
 msgid "Pieces"
 msgstr "Vorspielprogramm"
 
@@ -288,18 +288,18 @@ msgid "Role"
 msgstr "Rolle"
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:65
-#: lib/jumubase_web/views/performance_view.ex:120
+#: lib/jumubase_web/views/performance_view.ex:75
+#: lib/jumubase_web/views/performance_view.ex:123
 msgid "Soloist"
 msgstr "Solist"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:58
+#: lib/jumubase_web/templates/performance/_form.html.eex:56
 msgid "Add participant"
 msgstr "Teilnehmer hinzufügen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:68
+#: lib/jumubase_web/templates/performance/_form.html.eex:66
 msgid "Add piece"
 msgstr "Stück hinzufügen"
 
@@ -467,12 +467,12 @@ msgid "Password"
 msgstr "Passwort"
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:62
+#: lib/jumubase_web/views/performance_view.ex:72
 msgid "Participant"
 msgstr "Teilnehmer"
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:63
+#: lib/jumubase_web/views/performance_view.ex:73
 msgid "Piece"
 msgstr "Stück"
 
@@ -758,12 +758,12 @@ msgstr "Vor der Wertung"
 
 #, elixir-format
 #: lib/jumubase_web/templates/page/contact.html.eex:60
-#: lib/jumubase_web/templates/performance/_form.html.eex:76
+#: lib/jumubase_web/templates/performance/_form.html.eex:74
 msgid "privacy policy"
 msgstr "Datenschutzerklärung"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:75
+#: lib/jumubase_web/templates/performance/_form.html.eex:73
 msgid "The data you enter will be handled as described in the"
 msgstr "Wie wir deine Angaben verarbeiten, steht in der"
 
@@ -823,7 +823,7 @@ msgid "Show categories"
 msgstr "Kategorien anzeigen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:46
+#: lib/jumubase_web/templates/performance/_form.html.eex:44
 msgid "Who takes part?"
 msgstr "Wer nimmt teil?"
 
@@ -879,7 +879,7 @@ msgid "Show participants"
 msgstr "Teilnehmer anzeigen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:50
+#: lib/jumubase_web/templates/performance/_form.html.eex:48
 msgid "Non-competing accompanists don’t need to register."
 msgstr "Begleiter ohne Wertung müssen nicht angemeldet werden."
 
@@ -924,14 +924,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr "Bitte fülle nur sichtbare Felder im Kontaktformular aus."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:255
+#: lib/jumubase_web/views/internal/performance_view.ex:254
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] "%{count} Vorspiel"
 msgstr[1] "%{count} Vorspiele"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:261
+#: lib/jumubase_web/views/internal/performance_view.ex:260
 msgid "Filter active"
 msgstr "Filter aktiv"
 
@@ -987,7 +987,7 @@ msgid "The performance was deleted."
 msgstr "Das Vorspiel wurde gelöscht."
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/new.html.eex:13
+#: lib/jumubase_web/templates/internal/performance/new.html.eex:14
 msgid "Create Performance"
 msgstr "Vorspiel erstellen"
 
@@ -1406,14 +1406,14 @@ msgid "Publish results"
 msgstr "Ergebnisse freigeben"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:117
-#: lib/jumubase_web/views/internal/performance_view.ex:167
+#: lib/jumubase_web/views/internal/performance_view.ex:116
+#: lib/jumubase_web/views/internal/performance_view.ex:166
 msgid "No"
 msgstr "Nein"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:120
-#: lib/jumubase_web/views/internal/performance_view.ex:163
+#: lib/jumubase_web/views/internal/performance_view.ex:119
+#: lib/jumubase_web/views/internal/performance_view.ex:162
 msgid "Yes"
 msgstr "Ja"
 
@@ -1475,17 +1475,17 @@ msgid "Print certificates"
 msgstr "Urkunden ausgeben"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:205
+#: lib/jumubase_web/views/internal/performance_view.ex:204
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr "Tipp: Um ein eigenes Kimu-Logo hinzuzufügen, lege das bereits mit dem Logo bedruckte Papier erneut ein."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:211
+#: lib/jumubase_web/views/internal/performance_view.ex:210
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr "Die Ausgabe passt zum offiziellen Jumu-Urkundenpapier, welches du %{link} bestellen kannst."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:213
+#: lib/jumubase_web/views/internal/performance_view.ex:212
 msgid "here"
 msgstr "hier"
 
@@ -1819,6 +1819,11 @@ msgid "Allows registration"
 msgstr "Neuanmeldung erlaubt"
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:11
+#: lib/jumubase_web/templates/performance/_form.html.eex:9
 msgid "First round"
 msgstr "Regionalwettbewerb"
+
+#, elixir-format
+#: lib/jumubase_web/controllers/authorize.ex:156
+msgid "This contest is not open for registration. Please contact us if you need assistance."
+msgstr "Für diesen Wettbewerb ist die Anmeldung nicht möglich. Bitte kontaktiere uns, falls du Hilfe brauchst."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/user/index.html.eex:34
+#: lib/jumubase_web/templates/internal/user/index.html.eex:35
 msgid "Add User"
 msgstr "Neuen Benutzer hinzufügen"
 
@@ -28,7 +28,7 @@ msgid "Create User"
 msgstr "Benutzer erstellen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/user/index.html.eex:25
+#: lib/jumubase_web/templates/internal/user/index.html.eex:26
 msgid "Do you really want to delete this user?"
 msgstr "Möchtest du diesen Benutzer wirklich löschen?"
 
@@ -92,7 +92,7 @@ msgstr "Bitte wählen"
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/category/edit.html.eex:9
-#: lib/jumubase_web/templates/internal/contest/edit.html.eex:81 lib/jumubase_web/templates/internal/host/edit.html.eex:8
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:87 lib/jumubase_web/templates/internal/host/edit.html.eex:8
 #: lib/jumubase_web/templates/internal/performance/edit.html.eex:13 lib/jumubase_web/templates/internal/user/edit.html.eex:10
 #: lib/jumubase_web/templates/performance/edit.html.eex:13
 msgid "Save Changes"
@@ -211,7 +211,7 @@ msgid "Accompanist"
 msgstr "Begleiter"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:29
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:30
 #: lib/jumubase_web/templates/internal/participant/show.html.eex:8 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:75
 msgid "Birthdate"
 msgstr "Geburtsdatum"
@@ -219,7 +219,7 @@ msgstr "Geburtsdatum"
 #, elixir-format
 #: lib/jumubase_web/templates/internal/performance/advancing.html.eex:47
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:43
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
 #: lib/jumubase_web/templates/performance/_form.html.eex:9 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
@@ -232,7 +232,7 @@ msgid "Ensemblist"
 msgstr "Ensemblepartner"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:28
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:29
 #: lib/jumubase_web/templates/internal/user/form.html.eex:6 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:47
 msgid "First name"
 msgstr "Vorname"
@@ -243,7 +243,7 @@ msgid "Instrument"
 msgstr "Instrument"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:27
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:28
 #: lib/jumubase_web/templates/internal/user/form.html.eex:14 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:61
 msgid "Last name"
 msgstr "Nachname"
@@ -253,7 +253,7 @@ msgstr "Nachname"
 #: lib/jumubase_web/templates/internal/contest/_jumu_stats.html.eex:5 lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:5
 #: lib/jumubase_web/templates/internal/participant/index.html.eex:2 lib/jumubase_web/templates/internal/performance/advancing.html.eex:48
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:37 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:23
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:33 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:44
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:33 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:46
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:52 lib/jumubase_web/templates/internal/performance/show.html.eex:19
 #: lib/jumubase_web/templates/internal/stage/timetable.html.eex:32 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:224
 msgid "Participants"
@@ -503,7 +503,7 @@ msgid "If you've lost your edit code, ask your local Jumu organizer to retrieve 
 msgstr "Wenn du den Änderungscode verloren hast, hilft dir die Jumu-Kontaktperson deiner Schule weiter."
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:32
+#: lib/jumubase_web/controllers/page_controller.ex:35
 msgid "Please enter an edit code."
 msgstr "Bitte gib einen Änderungscode ein."
 
@@ -513,7 +513,7 @@ msgid "Search"
 msgstr "Suchen"
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:72
+#: lib/jumubase_web/controllers/page_controller.ex:75
 msgid "We could not find a registration for this edit code."
 msgstr "Wir konnten keine Anmeldung unter diesem Änderungscode finden."
 
@@ -869,7 +869,7 @@ msgstr "Weitere anzeigen…"
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/contest/_jumu_stats.html.eex:7
-#: lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:7 lib/jumubase_web/templates/internal/participant/index.html.eex:30
+#: lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:7 lib/jumubase_web/templates/internal/participant/index.html.eex:31
 msgid "Appearances"
 msgstr "Auftritte"
 
@@ -899,7 +899,7 @@ msgid "Certificate date"
 msgstr "Urkundendatum"
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:77
+#: lib/jumubase_web/controllers/page_controller.ex:80
 msgid "The edit deadline for this contest has passed. Please contact us if you need assistance."
 msgstr "Der Änderungsschluss für diesen Wettbewerb ist bereits vorbei. Bitte kontaktiere uns, falls du Hilfe brauchst."
 
@@ -909,7 +909,7 @@ msgid "The registration deadline for this contest has passed. Please contact us 
 msgstr "Der Anmeldeschluss für diesen Wettbewerb ist bereits vorbei. Bitte kontaktiere uns, falls du Hilfe brauchst."
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:64
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:65
 msgid "Do you really want to delete this performance?"
 msgstr "Möchtest du dieses Vorspiel wirklich löschen?"
 
@@ -924,14 +924,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr "Bitte fülle nur sichtbare Felder im Kontaktformular aus."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:252
+#: lib/jumubase_web/views/internal/performance_view.ex:253
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] "%{count} Vorspiel"
 msgstr[1] "%{count} Vorspiele"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:258
+#: lib/jumubase_web/views/internal/performance_view.ex:259
 msgid "Filter active"
 msgstr "Filter aktiv"
 
@@ -997,7 +997,7 @@ msgid "New Performance"
 msgstr "Neues Vorspiel"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:73
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:74
 msgid "Add Performance"
 msgstr "Neues Vorspiel hinzufügen"
 
@@ -1035,7 +1035,7 @@ msgstr "Alle Bühnen"
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:26
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:42
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:44
 msgid "Stage time"
 msgstr "Vorspielzeit"
 
@@ -1062,23 +1062,23 @@ msgid "o’clock"
 msgstr "Uhr"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
 msgid "admin"
 msgstr "Admin"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
 msgid "Add stage"
 msgstr "Bühne hinzufügen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:26
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:27
 msgid "No stage found"
 msgstr "Keine Bühne gefunden"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:31
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
 msgid "To add a new stage, please contact the"
 msgstr "Um eine Bühne hinzuzufügen, kontaktiere bitte den"
 
@@ -1314,7 +1314,7 @@ msgid "Registrations"
 msgstr "Anmeldungen"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:20
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:21
 msgid "Print jury sheets"
 msgstr "Jurybögen ausgeben"
 
@@ -1330,7 +1330,7 @@ msgid "Result"
 msgstr "Ergebnis"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:28
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:30
 msgid "Print jury table"
 msgstr "Jurytabelle ausgeben"
 
@@ -1348,7 +1348,7 @@ msgid "points"
 msgstr "Punkte"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:80
 msgid "Timetables public"
 msgstr "Vorspielplan öffentlich"
 
@@ -1406,14 +1406,14 @@ msgid "Publish results"
 msgstr "Ergebnisse freigeben"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:114
-#: lib/jumubase_web/views/internal/performance_view.ex:164
+#: lib/jumubase_web/views/internal/performance_view.ex:115
+#: lib/jumubase_web/views/internal/performance_view.ex:165
 msgid "No"
 msgstr "Nein"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:117
-#: lib/jumubase_web/views/internal/performance_view.ex:160
+#: lib/jumubase_web/views/internal/performance_view.ex:118
+#: lib/jumubase_web/views/internal/performance_view.ex:161
 msgid "Yes"
 msgstr "Ja"
 
@@ -1475,17 +1475,17 @@ msgid "Print certificates"
 msgstr "Urkunden ausgeben"
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:202
+#: lib/jumubase_web/views/internal/performance_view.ex:203
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr "Tipp: Um ein eigenes Kimu-Logo hinzuzufügen, lege das bereits mit dem Logo bedruckte Papier erneut ein."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:208
+#: lib/jumubase_web/views/internal/performance_view.ex:209
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr "Die Ausgabe passt zum offiziellen Jumu-Urkundenpapier, welches du %{link} bestellen kannst."
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:210
+#: lib/jumubase_web/views/internal/performance_view.ex:211
 msgid "here"
 msgstr "hier"
 
@@ -1511,7 +1511,7 @@ msgid "Compose group email"
 msgstr "Rundmail schreiben"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/contest/show.html.eex:105
+#: lib/jumubase_web/templates/internal/contest/show.html.eex:106
 msgid "Statistics"
 msgstr "Statistik"
 
@@ -1613,12 +1613,12 @@ msgstr[0] "Der verwaiste Teilnehmer wurde gelöscht."
 msgstr[1] "Es wurden %{count} verwaiste Teilnehmer gelöscht."
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:18
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:19
 msgid "Do you really want to send the welcome emails?"
 msgstr "Möchtest du die Willkommensmails wirklich senden?"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:15
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:16
 msgid "Send welcome emails"
 msgstr "Willkommensmails senden"
 
@@ -1812,3 +1812,8 @@ msgstr "Qanun"
 #: lib/jumubase/showtime/instruments.ex:41
 msgid "Tabla"
 msgstr "Tabla"
+
+#, elixir-format
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
+msgid "Allows registration"
+msgstr "Neuanmeldung erlaubt"

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -99,6 +99,7 @@ msgstr "muss vor dem Beginn liegen"
 
 #, elixir-format
 #: lib/jumubase/showtime/participant.ex:44
+#: lib/jumubase/showtime/performance.ex:137
 msgid "can't be changed"
 msgstr "kann nicht geändert werden"
 
@@ -108,7 +109,7 @@ msgid "can only appear once in a performance"
 msgstr "darf nur einen Auftritt pro Vorspiel haben"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:43
+#: lib/jumubase/showtime/performance.ex:48
 msgid "must be unique"
 msgstr "muss eindeutig sein"
 
@@ -123,32 +124,32 @@ msgid "The password is too short."
 msgstr "Das Passwort ist zu kurz"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:124
+#: lib/jumubase/showtime/performance.ex:150
 msgid "The performance must have at least one participant."
 msgstr "Das Vorspiel muss mindestens einen Teilnehmer haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:169
+#: lib/jumubase/showtime/performance.ex:195
 msgid "The performance must have at least one piece."
 msgstr "Das Vorspiel muss mindestens ein Stück haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:133
+#: lib/jumubase/showtime/performance.ex:159
 msgid "The performance can't have both soloists and ensemblists."
 msgstr "Das Vorspiel darf nicht sowohl Solisten als auch Ensemblepartner haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:140
+#: lib/jumubase/showtime/performance.ex:166
 msgid "The performance can't have more than one soloist."
 msgstr "Das Vorspiel darf nicht mehrere Solisten haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:154
+#: lib/jumubase/showtime/performance.ex:180
 msgid "The performance can't have only accompanists."
 msgstr "Das Vorspiel darf nicht nur Begleiter haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:147
+#: lib/jumubase/showtime/performance.ex:173
 msgid "The performance can't have only one ensemblist."
 msgstr "Das Vorspiel darf nicht nur einen Ensemblepartner haben."
 
@@ -178,6 +179,6 @@ msgid "can't be before the end date"
 msgstr "kann nicht vor dem Ende liegen"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:186
+#: lib/jumubase/showtime/performance.ex:212
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -99,7 +99,7 @@ msgstr "muss vor dem Beginn liegen"
 
 #, elixir-format
 #: lib/jumubase/showtime/participant.ex:44
-#: lib/jumubase/showtime/performance.ex:137
+#: lib/jumubase/showtime/performance.ex:140
 msgid "can't be changed"
 msgstr "kann nicht geändert werden"
 
@@ -109,7 +109,7 @@ msgid "can only appear once in a performance"
 msgstr "darf nur einen Auftritt pro Vorspiel haben"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:48
+#: lib/jumubase/showtime/performance.ex:49
 msgid "must be unique"
 msgstr "muss eindeutig sein"
 
@@ -124,32 +124,32 @@ msgid "The password is too short."
 msgstr "Das Passwort ist zu kurz"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:150
+#: lib/jumubase/showtime/performance.ex:153
 msgid "The performance must have at least one participant."
 msgstr "Das Vorspiel muss mindestens einen Teilnehmer haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:195
+#: lib/jumubase/showtime/performance.ex:198
 msgid "The performance must have at least one piece."
 msgstr "Das Vorspiel muss mindestens ein Stück haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:159
+#: lib/jumubase/showtime/performance.ex:162
 msgid "The performance can't have both soloists and ensemblists."
 msgstr "Das Vorspiel darf nicht sowohl Solisten als auch Ensemblepartner haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:166
+#: lib/jumubase/showtime/performance.ex:169
 msgid "The performance can't have more than one soloist."
 msgstr "Das Vorspiel darf nicht mehrere Solisten haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:180
+#: lib/jumubase/showtime/performance.ex:183
 msgid "The performance can't have only accompanists."
 msgstr "Das Vorspiel darf nicht nur Begleiter haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:173
+#: lib/jumubase/showtime/performance.ex:176
 msgid "The performance can't have only one ensemblist."
 msgstr "Das Vorspiel darf nicht nur einen Ensemblepartner haben."
 
@@ -179,6 +179,6 @@ msgid "can't be before the end date"
 msgstr "kann nicht vor dem Ende liegen"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:212
+#: lib/jumubase/showtime/performance.ex:215
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -88,12 +88,12 @@ msgid "must be equal to %{number}"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:59
+#: lib/jumubase/foundation/contest.ex:60
 msgid "can't be before the start date"
 msgstr "kann nicht vor dem Beginn liegen"
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:62
+#: lib/jumubase/foundation/contest.ex:63
 msgid "must be before the start date"
 msgstr "muss vor dem Beginn liegen"
 
@@ -108,7 +108,7 @@ msgid "can only appear once in a performance"
 msgstr "darf nur einen Auftritt pro Vorspiel haben"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:42
+#: lib/jumubase/showtime/performance.ex:43
 msgid "must be unique"
 msgstr "muss eindeutig sein"
 
@@ -123,32 +123,32 @@ msgid "The password is too short."
 msgstr "Das Passwort ist zu kurz"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:123
+#: lib/jumubase/showtime/performance.ex:124
 msgid "The performance must have at least one participant."
 msgstr "Das Vorspiel muss mindestens einen Teilnehmer haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:168
+#: lib/jumubase/showtime/performance.ex:169
 msgid "The performance must have at least one piece."
 msgstr "Das Vorspiel muss mindestens ein Stück haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:132
+#: lib/jumubase/showtime/performance.ex:133
 msgid "The performance can't have both soloists and ensemblists."
 msgstr "Das Vorspiel darf nicht sowohl Solisten als auch Ensemblepartner haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:139
+#: lib/jumubase/showtime/performance.ex:140
 msgid "The performance can't have more than one soloist."
 msgstr "Das Vorspiel darf nicht mehrere Solisten haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:153
+#: lib/jumubase/showtime/performance.ex:154
 msgid "The performance can't have only accompanists."
 msgstr "Das Vorspiel darf nicht nur Begleiter haben."
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:146
+#: lib/jumubase/showtime/performance.ex:147
 msgid "The performance can't have only one ensemblist."
 msgstr "Das Vorspiel darf nicht nur einen Ensemblepartner haben."
 
@@ -173,11 +173,11 @@ msgid "Oh no…"
 msgstr "Oh je…"
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:68
+#: lib/jumubase/foundation/contest.ex:69
 msgid "can't be before the end date"
 msgstr "kann nicht vor dem Ende liegen"
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:185
+#: lib/jumubase/showtime/performance.ex:186
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -84,16 +84,16 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:24
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:35 lib/jumubase_web/templates/internal/category/_form.html.eex:46
 #: lib/jumubase_web/templates/internal/user/form.html.eex:42 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:139
-#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:22
-#: lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
+#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:13
+#: lib/jumubase_web/templates/performance/_form.html.eex:35 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
 msgid "Please choose"
 msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/category/edit.html.eex:9
 #: lib/jumubase_web/templates/internal/contest/edit.html.eex:87 lib/jumubase_web/templates/internal/host/edit.html.eex:8
-#: lib/jumubase_web/templates/internal/performance/edit.html.eex:13 lib/jumubase_web/templates/internal/user/edit.html.eex:10
-#: lib/jumubase_web/templates/performance/edit.html.eex:13
+#: lib/jumubase_web/templates/internal/performance/edit.html.eex:14 lib/jumubase_web/templates/internal/user/edit.html.eex:10
+#: lib/jumubase_web/templates/performance/edit.html.eex:14
 msgid "Save Changes"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:67
-#: lib/jumubase_web/views/performance_view.ex:114
+#: lib/jumubase_web/views/performance_view.ex:121
 msgid "Accompanist"
 msgstr ""
 
@@ -220,13 +220,13 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
-#: lib/jumubase_web/templates/performance/_form.html.eex:9 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
+#: lib/jumubase_web/templates/performance/_form.html.eex:22 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
 msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:66
-#: lib/jumubase_web/views/performance_view.ex:115
+#: lib/jumubase_web/views/performance_view.ex:122
 msgid "Ensemblist"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgid "Phone"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:48
+#: lib/jumubase_web/templates/performance/_form.html.eex:61
 msgid "Pieces"
 msgstr ""
 
@@ -288,17 +288,17 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:65
-#: lib/jumubase_web/views/performance_view.ex:113
+#: lib/jumubase_web/views/performance_view.ex:120
 msgid "Soloist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:45
+#: lib/jumubase_web/templates/performance/_form.html.eex:58
 msgid "Add participant"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:55
+#: lib/jumubase_web/templates/performance/_form.html.eex:68
 msgid "Add piece"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgid "Programme"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/new.html.eex:14
+#: lib/jumubase_web/templates/performance/new.html.eex:15
 msgid "Submit registration"
 msgstr ""
 
@@ -757,12 +757,12 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/page/contact.html.eex:60
-#: lib/jumubase_web/templates/performance/_form.html.eex:63
+#: lib/jumubase_web/templates/performance/_form.html.eex:76
 msgid "privacy policy"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:62
+#: lib/jumubase_web/templates/performance/_form.html.eex:75
 msgid "The data you enter will be handled as described in the"
 msgstr ""
 
@@ -822,7 +822,7 @@ msgid "Show categories"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:33
+#: lib/jumubase_web/templates/performance/_form.html.eex:46
 msgid "Who takes part?"
 msgstr ""
 
@@ -878,7 +878,7 @@ msgid "Show participants"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:37
+#: lib/jumubase_web/templates/performance/_form.html.eex:50
 msgid "Non-competing accompanists don’t need to register."
 msgstr ""
 
@@ -923,14 +923,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:253
+#: lib/jumubase_web/views/internal/performance_view.ex:255
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:259
+#: lib/jumubase_web/views/internal/performance_view.ex:261
 msgid "Filter active"
 msgstr ""
 
@@ -1405,14 +1405,14 @@ msgid "Publish results"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:115
-#: lib/jumubase_web/views/internal/performance_view.ex:165
+#: lib/jumubase_web/views/internal/performance_view.ex:117
+#: lib/jumubase_web/views/internal/performance_view.ex:167
 msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:118
-#: lib/jumubase_web/views/internal/performance_view.ex:161
+#: lib/jumubase_web/views/internal/performance_view.ex:120
+#: lib/jumubase_web/views/internal/performance_view.ex:163
 msgid "Yes"
 msgstr ""
 
@@ -1474,17 +1474,17 @@ msgid "Print certificates"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:203
+#: lib/jumubase_web/views/internal/performance_view.ex:205
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:209
+#: lib/jumubase_web/views/internal/performance_view.ex:211
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:211
+#: lib/jumubase_web/views/internal/performance_view.ex:213
 msgid "here"
 msgstr ""
 
@@ -1815,4 +1815,9 @@ msgstr ""
 #, elixir-format
 #: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
 msgid "Allows registration"
+msgstr ""
+
+#, elixir-format
+#: lib/jumubase_web/templates/performance/_form.html.eex:11
+msgid "First round"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -84,8 +84,8 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:24
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:35 lib/jumubase_web/templates/internal/category/_form.html.eex:46
 #: lib/jumubase_web/templates/internal/user/form.html.eex:42 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:139
-#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:13
-#: lib/jumubase_web/templates/performance/_form.html.eex:35 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
+#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:11
+#: lib/jumubase_web/templates/performance/_form.html.eex:33 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
 msgid "Please choose"
 msgstr ""
 
@@ -204,8 +204,8 @@ msgid "Time zone"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:67
-#: lib/jumubase_web/views/performance_view.ex:121
+#: lib/jumubase_web/views/performance_view.ex:77
+#: lib/jumubase_web/views/performance_view.ex:124
 msgid "Accompanist"
 msgstr ""
 
@@ -220,13 +220,13 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
-#: lib/jumubase_web/templates/performance/_form.html.eex:22 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
+#: lib/jumubase_web/templates/performance/_form.html.eex:20 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:66
-#: lib/jumubase_web/views/performance_view.ex:122
+#: lib/jumubase_web/views/performance_view.ex:76
+#: lib/jumubase_web/views/performance_view.ex:125
 msgid "Ensemblist"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgid "Phone"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:61
+#: lib/jumubase_web/templates/performance/_form.html.eex:59
 msgid "Pieces"
 msgstr ""
 
@@ -287,18 +287,18 @@ msgid "Role"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:65
-#: lib/jumubase_web/views/performance_view.ex:120
+#: lib/jumubase_web/views/performance_view.ex:75
+#: lib/jumubase_web/views/performance_view.ex:123
 msgid "Soloist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:58
+#: lib/jumubase_web/templates/performance/_form.html.eex:56
 msgid "Add participant"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:68
+#: lib/jumubase_web/templates/performance/_form.html.eex:66
 msgid "Add piece"
 msgstr ""
 
@@ -466,12 +466,12 @@ msgid "Password"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:62
+#: lib/jumubase_web/views/performance_view.ex:72
 msgid "Participant"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:63
+#: lib/jumubase_web/views/performance_view.ex:73
 msgid "Piece"
 msgstr ""
 
@@ -757,12 +757,12 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/page/contact.html.eex:60
-#: lib/jumubase_web/templates/performance/_form.html.eex:76
+#: lib/jumubase_web/templates/performance/_form.html.eex:74
 msgid "privacy policy"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:75
+#: lib/jumubase_web/templates/performance/_form.html.eex:73
 msgid "The data you enter will be handled as described in the"
 msgstr ""
 
@@ -822,7 +822,7 @@ msgid "Show categories"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:46
+#: lib/jumubase_web/templates/performance/_form.html.eex:44
 msgid "Who takes part?"
 msgstr ""
 
@@ -878,7 +878,7 @@ msgid "Show participants"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:50
+#: lib/jumubase_web/templates/performance/_form.html.eex:48
 msgid "Non-competing accompanists don’t need to register."
 msgstr ""
 
@@ -923,14 +923,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:255
+#: lib/jumubase_web/views/internal/performance_view.ex:254
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:261
+#: lib/jumubase_web/views/internal/performance_view.ex:260
 msgid "Filter active"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgid "The performance was deleted."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/new.html.eex:13
+#: lib/jumubase_web/templates/internal/performance/new.html.eex:14
 msgid "Create Performance"
 msgstr ""
 
@@ -1405,14 +1405,14 @@ msgid "Publish results"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:117
-#: lib/jumubase_web/views/internal/performance_view.ex:167
+#: lib/jumubase_web/views/internal/performance_view.ex:116
+#: lib/jumubase_web/views/internal/performance_view.ex:166
 msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:120
-#: lib/jumubase_web/views/internal/performance_view.ex:163
+#: lib/jumubase_web/views/internal/performance_view.ex:119
+#: lib/jumubase_web/views/internal/performance_view.ex:162
 msgid "Yes"
 msgstr ""
 
@@ -1474,17 +1474,17 @@ msgid "Print certificates"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:205
+#: lib/jumubase_web/views/internal/performance_view.ex:204
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:211
+#: lib/jumubase_web/views/internal/performance_view.ex:210
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:213
+#: lib/jumubase_web/views/internal/performance_view.ex:212
 msgid "here"
 msgstr ""
 
@@ -1818,6 +1818,11 @@ msgid "Allows registration"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:11
+#: lib/jumubase_web/templates/performance/_form.html.eex:9
 msgid "First round"
+msgstr ""
+
+#, elixir-format
+#: lib/jumubase_web/controllers/authorize.ex:156
+msgid "This contest is not open for registration. Please contact us if you need assistance."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/user/index.html.eex:34
+#: lib/jumubase_web/templates/internal/user/index.html.eex:35
 msgid "Add User"
 msgstr ""
 
@@ -27,7 +27,7 @@ msgid "Create User"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/user/index.html.eex:25
+#: lib/jumubase_web/templates/internal/user/index.html.eex:26
 msgid "Do you really want to delete this user?"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/category/edit.html.eex:9
-#: lib/jumubase_web/templates/internal/contest/edit.html.eex:81 lib/jumubase_web/templates/internal/host/edit.html.eex:8
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:87 lib/jumubase_web/templates/internal/host/edit.html.eex:8
 #: lib/jumubase_web/templates/internal/performance/edit.html.eex:13 lib/jumubase_web/templates/internal/user/edit.html.eex:10
 #: lib/jumubase_web/templates/performance/edit.html.eex:13
 msgid "Save Changes"
@@ -210,7 +210,7 @@ msgid "Accompanist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:29
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:30
 #: lib/jumubase_web/templates/internal/participant/show.html.eex:8 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:75
 msgid "Birthdate"
 msgstr ""
@@ -218,7 +218,7 @@ msgstr ""
 #, elixir-format
 #: lib/jumubase_web/templates/internal/performance/advancing.html.eex:47
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:43
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
 #: lib/jumubase_web/templates/performance/_form.html.eex:9 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
@@ -231,7 +231,7 @@ msgid "Ensemblist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:28
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:29
 #: lib/jumubase_web/templates/internal/user/form.html.eex:6 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:47
 msgid "First name"
 msgstr ""
@@ -242,7 +242,7 @@ msgid "Instrument"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:27
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:28
 #: lib/jumubase_web/templates/internal/user/form.html.eex:14 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:61
 msgid "Last name"
 msgstr ""
@@ -252,7 +252,7 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/contest/_jumu_stats.html.eex:5 lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:5
 #: lib/jumubase_web/templates/internal/participant/index.html.eex:2 lib/jumubase_web/templates/internal/performance/advancing.html.eex:48
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:37 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:23
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:33 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:44
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:33 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:46
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:52 lib/jumubase_web/templates/internal/performance/show.html.eex:19
 #: lib/jumubase_web/templates/internal/stage/timetable.html.eex:32 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:224
 msgid "Participants"
@@ -502,7 +502,7 @@ msgid "If you've lost your edit code, ask your local Jumu organizer to retrieve 
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:32
+#: lib/jumubase_web/controllers/page_controller.ex:35
 msgid "Please enter an edit code."
 msgstr ""
 
@@ -512,7 +512,7 @@ msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:72
+#: lib/jumubase_web/controllers/page_controller.ex:75
 msgid "We could not find a registration for this edit code."
 msgstr ""
 
@@ -868,7 +868,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/contest/_jumu_stats.html.eex:7
-#: lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:7 lib/jumubase_web/templates/internal/participant/index.html.eex:30
+#: lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:7 lib/jumubase_web/templates/internal/participant/index.html.eex:31
 msgid "Appearances"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgid "Certificate date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:77
+#: lib/jumubase_web/controllers/page_controller.ex:80
 msgid "The edit deadline for this contest has passed. Please contact us if you need assistance."
 msgstr ""
 
@@ -908,7 +908,7 @@ msgid "The registration deadline for this contest has passed. Please contact us 
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:64
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:65
 msgid "Do you really want to delete this performance?"
 msgstr ""
 
@@ -923,14 +923,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:252
+#: lib/jumubase_web/views/internal/performance_view.ex:253
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:258
+#: lib/jumubase_web/views/internal/performance_view.ex:259
 msgid "Filter active"
 msgstr ""
 
@@ -996,7 +996,7 @@ msgid "New Performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:73
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:74
 msgid "Add Performance"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:26
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:42
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:44
 msgid "Stage time"
 msgstr ""
 
@@ -1061,23 +1061,23 @@ msgid "o’clock"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
 msgid "admin"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
 msgid "Add stage"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:26
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:27
 msgid "No stage found"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:31
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
 msgid "To add a new stage, please contact the"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgid "Registrations"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:20
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:21
 msgid "Print jury sheets"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgid "Result"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:28
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:30
 msgid "Print jury table"
 msgstr ""
 
@@ -1347,7 +1347,7 @@ msgid "points"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:80
 msgid "Timetables public"
 msgstr ""
 
@@ -1405,14 +1405,14 @@ msgid "Publish results"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:114
-#: lib/jumubase_web/views/internal/performance_view.ex:164
+#: lib/jumubase_web/views/internal/performance_view.ex:115
+#: lib/jumubase_web/views/internal/performance_view.ex:165
 msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:117
-#: lib/jumubase_web/views/internal/performance_view.ex:160
+#: lib/jumubase_web/views/internal/performance_view.ex:118
+#: lib/jumubase_web/views/internal/performance_view.ex:161
 msgid "Yes"
 msgstr ""
 
@@ -1474,17 +1474,17 @@ msgid "Print certificates"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:202
+#: lib/jumubase_web/views/internal/performance_view.ex:203
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:208
+#: lib/jumubase_web/views/internal/performance_view.ex:209
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:210
+#: lib/jumubase_web/views/internal/performance_view.ex:211
 msgid "here"
 msgstr ""
 
@@ -1510,7 +1510,7 @@ msgid "Compose group email"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/contest/show.html.eex:105
+#: lib/jumubase_web/templates/internal/contest/show.html.eex:106
 msgid "Statistics"
 msgstr ""
 
@@ -1612,12 +1612,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:18
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:19
 msgid "Do you really want to send the welcome emails?"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:15
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:16
 msgid "Send welcome emails"
 msgstr ""
 
@@ -1810,4 +1810,9 @@ msgstr ""
 #, elixir-format
 #: lib/jumubase/showtime/instruments.ex:41
 msgid "Tabla"
+msgstr ""
+
+#, elixir-format
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
+msgid "Allows registration"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/auth.po
+++ b/priv/gettext/en/LC_MESSAGES/auth.po
@@ -37,7 +37,7 @@ msgid "You are now logged out."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/authorize.ex:173
+#: lib/jumubase_web/controllers/authorize.ex:183
 msgid "You need to log in to view this page."
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -85,16 +85,16 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:24
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:35 lib/jumubase_web/templates/internal/category/_form.html.eex:46
 #: lib/jumubase_web/templates/internal/user/form.html.eex:42 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:139
-#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:22
-#: lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
+#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:13
+#: lib/jumubase_web/templates/performance/_form.html.eex:35 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
 msgid "Please choose"
 msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/category/edit.html.eex:9
 #: lib/jumubase_web/templates/internal/contest/edit.html.eex:87 lib/jumubase_web/templates/internal/host/edit.html.eex:8
-#: lib/jumubase_web/templates/internal/performance/edit.html.eex:13 lib/jumubase_web/templates/internal/user/edit.html.eex:10
-#: lib/jumubase_web/templates/performance/edit.html.eex:13
+#: lib/jumubase_web/templates/internal/performance/edit.html.eex:14 lib/jumubase_web/templates/internal/user/edit.html.eex:10
+#: lib/jumubase_web/templates/performance/edit.html.eex:14
 msgid "Save Changes"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:67
-#: lib/jumubase_web/views/performance_view.ex:114
+#: lib/jumubase_web/views/performance_view.ex:121
 msgid "Accompanist"
 msgstr ""
 
@@ -221,13 +221,13 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
-#: lib/jumubase_web/templates/performance/_form.html.eex:9 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
+#: lib/jumubase_web/templates/performance/_form.html.eex:22 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
 msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:66
-#: lib/jumubase_web/views/performance_view.ex:115
+#: lib/jumubase_web/views/performance_view.ex:122
 msgid "Ensemblist"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgid "Phone"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:48
+#: lib/jumubase_web/templates/performance/_form.html.eex:61
 msgid "Pieces"
 msgstr ""
 
@@ -289,17 +289,17 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/views/performance_view.ex:65
-#: lib/jumubase_web/views/performance_view.ex:113
+#: lib/jumubase_web/views/performance_view.ex:120
 msgid "Soloist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:45
+#: lib/jumubase_web/templates/performance/_form.html.eex:58
 msgid "Add participant"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:55
+#: lib/jumubase_web/templates/performance/_form.html.eex:68
 msgid "Add piece"
 msgstr ""
 
@@ -392,7 +392,7 @@ msgid "Programme"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/new.html.eex:14
+#: lib/jumubase_web/templates/performance/new.html.eex:15
 msgid "Submit registration"
 msgstr ""
 
@@ -758,12 +758,12 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/page/contact.html.eex:60
-#: lib/jumubase_web/templates/performance/_form.html.eex:63
+#: lib/jumubase_web/templates/performance/_form.html.eex:76
 msgid "privacy policy"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:62
+#: lib/jumubase_web/templates/performance/_form.html.eex:75
 msgid "The data you enter will be handled as described in the"
 msgstr ""
 
@@ -823,7 +823,7 @@ msgid "Show categories"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:33
+#: lib/jumubase_web/templates/performance/_form.html.eex:46
 msgid "Who takes part?"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgid "Show participants"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:37
+#: lib/jumubase_web/templates/performance/_form.html.eex:50
 msgid "Non-competing accompanists don’t need to register."
 msgstr ""
 
@@ -924,14 +924,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:253
+#: lib/jumubase_web/views/internal/performance_view.ex:255
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:259
+#: lib/jumubase_web/views/internal/performance_view.ex:261
 msgid "Filter active"
 msgstr ""
 
@@ -1406,14 +1406,14 @@ msgid "Publish results"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:115
-#: lib/jumubase_web/views/internal/performance_view.ex:165
+#: lib/jumubase_web/views/internal/performance_view.ex:117
+#: lib/jumubase_web/views/internal/performance_view.ex:167
 msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:118
-#: lib/jumubase_web/views/internal/performance_view.ex:161
+#: lib/jumubase_web/views/internal/performance_view.ex:120
+#: lib/jumubase_web/views/internal/performance_view.ex:163
 msgid "Yes"
 msgstr ""
 
@@ -1475,17 +1475,17 @@ msgid "Print certificates"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:203
+#: lib/jumubase_web/views/internal/performance_view.ex:205
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:209
+#: lib/jumubase_web/views/internal/performance_view.ex:211
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:211
+#: lib/jumubase_web/views/internal/performance_view.ex:213
 msgid "here"
 msgstr ""
 
@@ -1816,4 +1816,9 @@ msgstr ""
 #, elixir-format
 #: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
 msgid "Allows registration"
+msgstr ""
+
+#, elixir-format
+#: lib/jumubase_web/templates/performance/_form.html.eex:11
+msgid "First round"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/user/index.html.eex:34
+#: lib/jumubase_web/templates/internal/user/index.html.eex:35
 msgid "Add User"
 msgstr ""
 
@@ -28,7 +28,7 @@ msgid "Create User"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/user/index.html.eex:25
+#: lib/jumubase_web/templates/internal/user/index.html.eex:26
 msgid "Do you really want to delete this user?"
 msgstr ""
 
@@ -92,7 +92,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/category/edit.html.eex:9
-#: lib/jumubase_web/templates/internal/contest/edit.html.eex:81 lib/jumubase_web/templates/internal/host/edit.html.eex:8
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:87 lib/jumubase_web/templates/internal/host/edit.html.eex:8
 #: lib/jumubase_web/templates/internal/performance/edit.html.eex:13 lib/jumubase_web/templates/internal/user/edit.html.eex:10
 #: lib/jumubase_web/templates/performance/edit.html.eex:13
 msgid "Save Changes"
@@ -211,7 +211,7 @@ msgid "Accompanist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:29
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:30
 #: lib/jumubase_web/templates/internal/participant/show.html.eex:8 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:75
 msgid "Birthdate"
 msgstr ""
@@ -219,7 +219,7 @@ msgstr ""
 #, elixir-format
 #: lib/jumubase_web/templates/internal/performance/advancing.html.eex:47
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:43
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
 #: lib/jumubase_web/templates/performance/_form.html.eex:9 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
@@ -232,7 +232,7 @@ msgid "Ensemblist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:28
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:29
 #: lib/jumubase_web/templates/internal/user/form.html.eex:6 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:47
 msgid "First name"
 msgstr ""
@@ -243,7 +243,7 @@ msgid "Instrument"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:27
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:28
 #: lib/jumubase_web/templates/internal/user/form.html.eex:14 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:61
 msgid "Last name"
 msgstr ""
@@ -253,7 +253,7 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/contest/_jumu_stats.html.eex:5 lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:5
 #: lib/jumubase_web/templates/internal/participant/index.html.eex:2 lib/jumubase_web/templates/internal/performance/advancing.html.eex:48
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:37 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:23
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:33 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:44
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:33 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:46
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:52 lib/jumubase_web/templates/internal/performance/show.html.eex:19
 #: lib/jumubase_web/templates/internal/stage/timetable.html.eex:32 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:224
 msgid "Participants"
@@ -503,7 +503,7 @@ msgid "If you've lost your edit code, ask your local Jumu organizer to retrieve 
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:32
+#: lib/jumubase_web/controllers/page_controller.ex:35
 msgid "Please enter an edit code."
 msgstr ""
 
@@ -513,7 +513,7 @@ msgid "Search"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:72
+#: lib/jumubase_web/controllers/page_controller.ex:75
 msgid "We could not find a registration for this edit code."
 msgstr ""
 
@@ -869,7 +869,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/contest/_jumu_stats.html.eex:7
-#: lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:7 lib/jumubase_web/templates/internal/participant/index.html.eex:30
+#: lib/jumubase_web/templates/internal/contest/_kimu_stats.html.eex:7 lib/jumubase_web/templates/internal/participant/index.html.eex:31
 msgid "Appearances"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgid "Certificate date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/controllers/page_controller.ex:77
+#: lib/jumubase_web/controllers/page_controller.ex:80
 msgid "The edit deadline for this contest has passed. Please contact us if you need assistance."
 msgstr ""
 
@@ -909,7 +909,7 @@ msgid "The registration deadline for this contest has passed. Please contact us 
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:64
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:65
 msgid "Do you really want to delete this performance?"
 msgstr ""
 
@@ -924,14 +924,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:252
+#: lib/jumubase_web/views/internal/performance_view.ex:253
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:258
+#: lib/jumubase_web/views/internal/performance_view.ex:259
 msgid "Filter active"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgid "New Performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/index.html.eex:73
+#: lib/jumubase_web/templates/internal/performance/index.html.eex:74
 msgid "Add Performance"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:26
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:42
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:44
 msgid "Stage time"
 msgstr ""
 
@@ -1062,23 +1062,23 @@ msgid "o’clock"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
 msgid "admin"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:33
 msgid "Add stage"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:26
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:27
 msgid "No stage found"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/stage/index.html.eex:31
+#: lib/jumubase_web/templates/internal/stage/index.html.eex:32
 msgid "To add a new stage, please contact the"
 msgstr ""
 
@@ -1314,7 +1314,7 @@ msgid "Registrations"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:20
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:21
 msgid "Print jury sheets"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgid "Result"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:28
+#: lib/jumubase_web/templates/internal/performance/jury_material.html.eex:30
 msgid "Print jury table"
 msgstr ""
 
@@ -1348,7 +1348,7 @@ msgid "points"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:80
 msgid "Timetables public"
 msgstr ""
 
@@ -1406,14 +1406,14 @@ msgid "Publish results"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:114
-#: lib/jumubase_web/views/internal/performance_view.ex:164
+#: lib/jumubase_web/views/internal/performance_view.ex:115
+#: lib/jumubase_web/views/internal/performance_view.ex:165
 msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:117
-#: lib/jumubase_web/views/internal/performance_view.ex:160
+#: lib/jumubase_web/views/internal/performance_view.ex:118
+#: lib/jumubase_web/views/internal/performance_view.ex:161
 msgid "Yes"
 msgstr ""
 
@@ -1475,17 +1475,17 @@ msgid "Print certificates"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:202
+#: lib/jumubase_web/views/internal/performance_view.ex:203
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:208
+#: lib/jumubase_web/views/internal/performance_view.ex:209
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:210
+#: lib/jumubase_web/views/internal/performance_view.ex:211
 msgid "here"
 msgstr ""
 
@@ -1511,7 +1511,7 @@ msgid "Compose group email"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/contest/show.html.eex:105
+#: lib/jumubase_web/templates/internal/contest/show.html.eex:106
 msgid "Statistics"
 msgstr ""
 
@@ -1613,12 +1613,12 @@ msgstr[0] "One orphaned participant was deleted."
 msgstr[1] "%{count} orphaned participants were deleted."
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:18
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:19
 msgid "Do you really want to send the welcome emails?"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/participant/index.html.eex:15
+#: lib/jumubase_web/templates/internal/participant/index.html.eex:16
 msgid "Send welcome emails"
 msgstr ""
 
@@ -1811,4 +1811,9 @@ msgstr ""
 #, elixir-format
 #: lib/jumubase/showtime/instruments.ex:41
 msgid "Tabla"
+msgstr ""
+
+#, elixir-format
+#: lib/jumubase_web/templates/internal/contest/edit.html.eex:74
+msgid "Allows registration"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -85,8 +85,8 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:24
 #: lib/jumubase_web/templates/internal/category/_form.html.eex:35 lib/jumubase_web/templates/internal/category/_form.html.eex:46
 #: lib/jumubase_web/templates/internal/user/form.html.eex:42 lib/jumubase_web/templates/performance/_appearance_panels.html.eex:139
-#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:13
-#: lib/jumubase_web/templates/performance/_form.html.eex:35 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
+#: lib/jumubase_web/templates/performance/_appearance_panels.html.eex:160 lib/jumubase_web/templates/performance/_form.html.eex:11
+#: lib/jumubase_web/templates/performance/_form.html.eex:33 lib/jumubase_web/templates/performance/_piece_panels.html.eex:120
 msgid "Please choose"
 msgstr ""
 
@@ -205,8 +205,8 @@ msgid "Time zone"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:67
-#: lib/jumubase_web/views/performance_view.ex:121
+#: lib/jumubase_web/views/performance_view.ex:77
+#: lib/jumubase_web/views/performance_view.ex:124
 msgid "Accompanist"
 msgstr ""
 
@@ -221,13 +221,13 @@ msgstr ""
 #: lib/jumubase_web/templates/internal/performance/certificates.html.eex:36 lib/jumubase_web/templates/internal/performance/edit_results.html.eex:22
 #: lib/jumubase_web/templates/internal/performance/index.html.eex:27 lib/jumubase_web/templates/internal/performance/jury_material.html.eex:45
 #: lib/jumubase_web/templates/internal/performance/publish_results.html.eex:51 lib/jumubase_web/templates/internal/stage/timetable.html.eex:31
-#: lib/jumubase_web/templates/performance/_form.html.eex:22 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
+#: lib/jumubase_web/templates/performance/_form.html.eex:20 lib/jumubase_web/views/generators/pdf_generator/default_engine.ex:222
 msgid "Category"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:66
-#: lib/jumubase_web/views/performance_view.ex:122
+#: lib/jumubase_web/views/performance_view.ex:76
+#: lib/jumubase_web/views/performance_view.ex:125
 msgid "Ensemblist"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgid "Phone"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:61
+#: lib/jumubase_web/templates/performance/_form.html.eex:59
 msgid "Pieces"
 msgstr ""
 
@@ -288,18 +288,18 @@ msgid "Role"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:65
-#: lib/jumubase_web/views/performance_view.ex:120
+#: lib/jumubase_web/views/performance_view.ex:75
+#: lib/jumubase_web/views/performance_view.ex:123
 msgid "Soloist"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:58
+#: lib/jumubase_web/templates/performance/_form.html.eex:56
 msgid "Add participant"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:68
+#: lib/jumubase_web/templates/performance/_form.html.eex:66
 msgid "Add piece"
 msgstr ""
 
@@ -467,12 +467,12 @@ msgid "Password"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:62
+#: lib/jumubase_web/views/performance_view.ex:72
 msgid "Participant"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/performance_view.ex:63
+#: lib/jumubase_web/views/performance_view.ex:73
 msgid "Piece"
 msgstr ""
 
@@ -758,12 +758,12 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase_web/templates/page/contact.html.eex:60
-#: lib/jumubase_web/templates/performance/_form.html.eex:76
+#: lib/jumubase_web/templates/performance/_form.html.eex:74
 msgid "privacy policy"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:75
+#: lib/jumubase_web/templates/performance/_form.html.eex:73
 msgid "The data you enter will be handled as described in the"
 msgstr ""
 
@@ -823,7 +823,7 @@ msgid "Show categories"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:46
+#: lib/jumubase_web/templates/performance/_form.html.eex:44
 msgid "Who takes part?"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgid "Show participants"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:50
+#: lib/jumubase_web/templates/performance/_form.html.eex:48
 msgid "Non-competing accompanists don’t need to register."
 msgstr ""
 
@@ -924,14 +924,14 @@ msgid "Please fill in only fields that are visible in the form."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:255
+#: lib/jumubase_web/views/internal/performance_view.ex:254
 msgid "%{count} performance"
 msgid_plural "%{count} performances"
 msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:261
+#: lib/jumubase_web/views/internal/performance_view.ex:260
 msgid "Filter active"
 msgstr ""
 
@@ -987,7 +987,7 @@ msgid "The performance was deleted."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/internal/performance/new.html.eex:13
+#: lib/jumubase_web/templates/internal/performance/new.html.eex:14
 msgid "Create Performance"
 msgstr ""
 
@@ -1406,14 +1406,14 @@ msgid "Publish results"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:117
-#: lib/jumubase_web/views/internal/performance_view.ex:167
+#: lib/jumubase_web/views/internal/performance_view.ex:116
+#: lib/jumubase_web/views/internal/performance_view.ex:166
 msgid "No"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:120
-#: lib/jumubase_web/views/internal/performance_view.ex:163
+#: lib/jumubase_web/views/internal/performance_view.ex:119
+#: lib/jumubase_web/views/internal/performance_view.ex:162
 msgid "Yes"
 msgstr ""
 
@@ -1475,17 +1475,17 @@ msgid "Print certificates"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:205
+#: lib/jumubase_web/views/internal/performance_view.ex:204
 msgid "Pro tip: To add a custom Kimu logo, print it on paper first, then re-insert the printed paper."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:211
+#: lib/jumubase_web/views/internal/performance_view.ex:210
 msgid "The printed output matches the official Jumu certificate paper, which you can order %{link}."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/views/internal/performance_view.ex:213
+#: lib/jumubase_web/views/internal/performance_view.ex:212
 msgid "here"
 msgstr ""
 
@@ -1819,6 +1819,11 @@ msgid "Allows registration"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase_web/templates/performance/_form.html.eex:11
+#: lib/jumubase_web/templates/performance/_form.html.eex:9
 msgid "First round"
+msgstr ""
+
+#, elixir-format
+#: lib/jumubase_web/controllers/authorize.ex:156
+msgid "This contest is not open for registration. Please contact us if you need assistance."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -109,7 +109,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase/showtime/participant.ex:44
-#: lib/jumubase/showtime/performance.ex:137
+#: lib/jumubase/showtime/performance.ex:140
 msgid "can't be changed"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgid "can only appear once in a performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:48
+#: lib/jumubase/showtime/performance.ex:49
 msgid "must be unique"
 msgstr ""
 
@@ -134,32 +134,32 @@ msgid "The password is too short."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:150
+#: lib/jumubase/showtime/performance.ex:153
 msgid "The performance must have at least one participant."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:195
+#: lib/jumubase/showtime/performance.ex:198
 msgid "The performance must have at least one piece."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:159
+#: lib/jumubase/showtime/performance.ex:162
 msgid "The performance can't have both soloists and ensemblists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:166
+#: lib/jumubase/showtime/performance.ex:169
 msgid "The performance can't have more than one soloist."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:180
+#: lib/jumubase/showtime/performance.ex:183
 msgid "The performance can't have only accompanists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:173
+#: lib/jumubase/showtime/performance.ex:176
 msgid "The performance can't have only one ensemblist."
 msgstr ""
 
@@ -189,6 +189,6 @@ msgid "can't be before the end date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:212
+#: lib/jumubase/showtime/performance.ex:215
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -109,6 +109,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase/showtime/participant.ex:44
+#: lib/jumubase/showtime/performance.ex:137
 msgid "can't be changed"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgid "can only appear once in a performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:43
+#: lib/jumubase/showtime/performance.ex:48
 msgid "must be unique"
 msgstr ""
 
@@ -133,32 +134,32 @@ msgid "The password is too short."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:124
+#: lib/jumubase/showtime/performance.ex:150
 msgid "The performance must have at least one participant."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:169
+#: lib/jumubase/showtime/performance.ex:195
 msgid "The performance must have at least one piece."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:133
+#: lib/jumubase/showtime/performance.ex:159
 msgid "The performance can't have both soloists and ensemblists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:140
+#: lib/jumubase/showtime/performance.ex:166
 msgid "The performance can't have more than one soloist."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:154
+#: lib/jumubase/showtime/performance.ex:180
 msgid "The performance can't have only accompanists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:147
+#: lib/jumubase/showtime/performance.ex:173
 msgid "The performance can't have only one ensemblist."
 msgstr ""
 
@@ -188,6 +189,6 @@ msgid "can't be before the end date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:186
+#: lib/jumubase/showtime/performance.ex:212
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -98,12 +98,12 @@ msgid "must be equal to %{number}"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:59
+#: lib/jumubase/foundation/contest.ex:60
 msgid "can't be before the start date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:62
+#: lib/jumubase/foundation/contest.ex:63
 msgid "must be before the start date"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgid "can only appear once in a performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:42
+#: lib/jumubase/showtime/performance.ex:43
 msgid "must be unique"
 msgstr ""
 
@@ -133,32 +133,32 @@ msgid "The password is too short."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:123
+#: lib/jumubase/showtime/performance.ex:124
 msgid "The performance must have at least one participant."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:168
+#: lib/jumubase/showtime/performance.ex:169
 msgid "The performance must have at least one piece."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:132
+#: lib/jumubase/showtime/performance.ex:133
 msgid "The performance can't have both soloists and ensemblists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:139
+#: lib/jumubase/showtime/performance.ex:140
 msgid "The performance can't have more than one soloist."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:153
+#: lib/jumubase/showtime/performance.ex:154
 msgid "The performance can't have only accompanists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:146
+#: lib/jumubase/showtime/performance.ex:147
 msgid "The performance can't have only one ensemblist."
 msgstr ""
 
@@ -183,11 +183,11 @@ msgid "Oh no…"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:68
+#: lib/jumubase/foundation/contest.ex:69
 msgid "can't be before the end date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:185
+#: lib/jumubase/showtime/performance.ex:186
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -106,7 +106,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase/showtime/participant.ex:44
-#: lib/jumubase/showtime/performance.ex:137
+#: lib/jumubase/showtime/performance.ex:140
 msgid "can't be changed"
 msgstr ""
 
@@ -116,7 +116,7 @@ msgid "can only appear once in a performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:48
+#: lib/jumubase/showtime/performance.ex:49
 msgid "must be unique"
 msgstr ""
 
@@ -131,32 +131,32 @@ msgid "The password is too short."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:150
+#: lib/jumubase/showtime/performance.ex:153
 msgid "The performance must have at least one participant."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:195
+#: lib/jumubase/showtime/performance.ex:198
 msgid "The performance must have at least one piece."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:159
+#: lib/jumubase/showtime/performance.ex:162
 msgid "The performance can't have both soloists and ensemblists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:166
+#: lib/jumubase/showtime/performance.ex:169
 msgid "The performance can't have more than one soloist."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:180
+#: lib/jumubase/showtime/performance.ex:183
 msgid "The performance can't have only accompanists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:173
+#: lib/jumubase/showtime/performance.ex:176
 msgid "The performance can't have only one ensemblist."
 msgstr ""
 
@@ -186,6 +186,6 @@ msgid "can't be before the end date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:212
+#: lib/jumubase/showtime/performance.ex:215
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -106,6 +106,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/jumubase/showtime/participant.ex:44
+#: lib/jumubase/showtime/performance.ex:137
 msgid "can't be changed"
 msgstr ""
 
@@ -115,7 +116,7 @@ msgid "can only appear once in a performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:43
+#: lib/jumubase/showtime/performance.ex:48
 msgid "must be unique"
 msgstr ""
 
@@ -130,32 +131,32 @@ msgid "The password is too short."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:124
+#: lib/jumubase/showtime/performance.ex:150
 msgid "The performance must have at least one participant."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:169
+#: lib/jumubase/showtime/performance.ex:195
 msgid "The performance must have at least one piece."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:133
+#: lib/jumubase/showtime/performance.ex:159
 msgid "The performance can't have both soloists and ensemblists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:140
+#: lib/jumubase/showtime/performance.ex:166
 msgid "The performance can't have more than one soloist."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:154
+#: lib/jumubase/showtime/performance.ex:180
 msgid "The performance can't have only accompanists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:147
+#: lib/jumubase/showtime/performance.ex:173
 msgid "The performance can't have only one ensemblist."
 msgstr ""
 
@@ -185,6 +186,6 @@ msgid "can't be before the end date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:186
+#: lib/jumubase/showtime/performance.ex:212
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -95,12 +95,12 @@ msgid "must be equal to %{number}"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:59
+#: lib/jumubase/foundation/contest.ex:60
 msgid "can't be before the start date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:62
+#: lib/jumubase/foundation/contest.ex:63
 msgid "must be before the start date"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgid "can only appear once in a performance"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:42
+#: lib/jumubase/showtime/performance.ex:43
 msgid "must be unique"
 msgstr ""
 
@@ -130,32 +130,32 @@ msgid "The password is too short."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:123
+#: lib/jumubase/showtime/performance.ex:124
 msgid "The performance must have at least one participant."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:168
+#: lib/jumubase/showtime/performance.ex:169
 msgid "The performance must have at least one piece."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:132
+#: lib/jumubase/showtime/performance.ex:133
 msgid "The performance can't have both soloists and ensemblists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:139
+#: lib/jumubase/showtime/performance.ex:140
 msgid "The performance can't have more than one soloist."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:153
+#: lib/jumubase/showtime/performance.ex:154
 msgid "The performance can't have only accompanists."
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:146
+#: lib/jumubase/showtime/performance.ex:147
 msgid "The performance can't have only one ensemblist."
 msgstr ""
 
@@ -180,11 +180,11 @@ msgid "Oh no…"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/foundation/contest.ex:68
+#: lib/jumubase/foundation/contest.ex:69
 msgid "can't be before the end date"
 msgstr ""
 
 #, elixir-format
-#: lib/jumubase/showtime/performance.ex:185
+#: lib/jumubase/showtime/performance.ex:186
 msgid "The performance can either have both stage and stage time, or neither."
 msgstr ""

--- a/priv/repo/migrations/20191231204326_add_allows_registration_flag_to_contests.exs
+++ b/priv/repo/migrations/20191231204326_add_allows_registration_flag_to_contests.exs
@@ -1,0 +1,9 @@
+defmodule Jumubase.Repo.Migrations.AddAllowsRegistrationFlagToContests do
+  use Ecto.Migration
+
+  def change do
+    alter table(:contests) do
+      add :allows_registration, :boolean, null: false, default: true
+    end
+  end
+end

--- a/test/jumubase/foundation/foundation_test.exs
+++ b/test/jumubase/foundation/foundation_test.exs
@@ -534,13 +534,14 @@ defmodule Jumubase.FoundationTest do
 
   describe "get_successor/1" do
     test "returns the next-round (LW) successor for an RW contest" do
-      c1 = insert(:contest, season: 56, round: 1)
+      c1 = insert(:contest, season: 56, round: 1, grouping: "1")
       # Irrelevant contests
-      insert(:contest, season: 56, round: 0)
-      insert(:contest, season: 56, round: 1)
-      insert(:contest, season: 57, round: 2)
+      insert(:contest, season: 57, round: 2, grouping: "1")
+      insert(:contest, season: 56, round: 0, grouping: "1")
+      insert(:contest, season: 56, round: 1, grouping: "1")
+      insert(:contest, season: 56, round: 2, grouping: "2")
       # Successor contest
-      c2 = insert(:contest, season: 56, round: 2)
+      c2 = insert(:contest, season: 56, round: 2, grouping: "1")
 
       result = Foundation.get_successor(c1)
       assert result.id == c2.id

--- a/test/jumubase/foundation/foundation_test.exs
+++ b/test/jumubase/foundation/foundation_test.exs
@@ -34,19 +34,24 @@ defmodule Jumubase.FoundationTest do
 
   describe "list_predecessor_hosts/1" do
     setup do
-      [lw: insert(:contest, season: 56, round: 2)]
+      [lw: insert(:contest, season: 56, round: 2, grouping: "1")]
     end
 
     test "returns all hosts with predecessor contests of the given LW, ordered by name", %{lw: lw} do
+      h1 = insert(:host, name: "C")
+      h2 = insert(:host, name: "A")
+      h3 = insert(:host, name: "B")
+
       # Matching contests
-      %{host: h1} = insert(:contest, season: lw.season, round: 1, host: build(:host, name: "C"))
-      %{host: h2} = insert(:contest, season: lw.season, round: 1, host: build(:host, name: "A"))
-      %{host: h3} = insert(:contest, season: lw.season, round: 1, host: build(:host, name: "B"))
+      insert(:contest, season: lw.season, round: 1, grouping: "1", host: h1)
+      insert(:contest, season: lw.season, round: 1, grouping: "1", host: h2)
+      insert(:contest, season: lw.season, round: 1, grouping: "1", host: h3)
 
       # Non-matching contests
-      insert(:contest, season: lw.season - 1, round: 1)
-      insert(:contest, season: lw.season, round: 0)
-      insert(:contest, season: lw.season, round: 2)
+      insert(:contest, season: lw.season - 1, round: 1, grouping: "1")
+      insert(:contest, season: lw.season, round: 0, grouping: "1")
+      insert(:contest, season: lw.season, round: 2, grouping: "1")
+      insert(:contest, season: lw.season, round: 1, grouping: "2")
 
       assert_ids_match_ordered(Foundation.list_predecessor_hosts(lw), [h2, h3, h1])
     end

--- a/test/jumubase/foundation/foundation_test.exs
+++ b/test/jumubase/foundation/foundation_test.exs
@@ -173,13 +173,28 @@ defmodule Jumubase.FoundationTest do
       assert Foundation.list_open_contests(2) == [c2, c1, c3]
     end
 
-    test "does not return contests with a past signup deadline" do
-      yesterday = Timex.today() |> Timex.shift(days: -1)
-      insert(:contest, round: 0, deadline: yesterday)
-      insert(:contest, round: 1, deadline: yesterday)
+    test "does not return contests that don't allow registration" do
+      today = Timex.today()
+
+      insert(:contest, round: 0, allows_registration: false, deadline: today)
+      insert(:contest, round: 1, allows_registration: false, deadline: today)
+      insert(:contest, round: 2, allows_registration: false, deadline: today)
 
       assert Foundation.list_open_contests(0) == []
       assert Foundation.list_open_contests(1) == []
+      assert Foundation.list_open_contests(2) == []
+    end
+
+    test "does not return contests with a past signup deadline" do
+      yesterday = Timex.today() |> Timex.shift(days: -1)
+
+      insert(:contest, round: 0, deadline: yesterday)
+      insert(:contest, round: 1, deadline: yesterday)
+      insert(:contest, round: 2, deadline: yesterday)
+
+      assert Foundation.list_open_contests(0) == []
+      assert Foundation.list_open_contests(1) == []
+      assert Foundation.list_open_contests(2) == []
     end
   end
 

--- a/test/jumubase_web/controllers/page_controller_test.exs
+++ b/test/jumubase_web/controllers/page_controller_test.exs
@@ -10,20 +10,32 @@ defmodule JumubaseWeb.PageControllerTest do
   end
 
   describe "registration/2" do
-    test "lists open RW and Kimu contests", %{conn: conn} do
-      kimu = insert(:contest, round: 0, deadline: Timex.today())
-      rw = insert(:contest, round: 1, deadline: Timex.today())
+    test "lists open Kimu, RW and LW contests", %{conn: conn} do
+      today = Timex.today()
+
+      kimu = insert(:contest, round: 0, deadline: today)
+      rw = insert(:contest, round: 1, deadline: today)
+      lw = insert(:contest, round: 2, deadline: today)
+
       conn = get(conn, Routes.page_path(conn, :registration))
 
       assert html_response(conn, 200) =~ "Registration"
       assert html_response(conn, 200) =~ ContestView.name_with_flag(kimu)
       assert html_response(conn, 200) =~ ContestView.name_with_flag(rw)
+      assert html_response(conn, 200) =~ ContestView.name_with_flag(lw)
     end
 
-    test "does not list open LW contests", %{conn: conn} do
-      lw = insert(:contest, round: 2, deadline: Timex.today())
+    test "does not list contests that don't allow registration", %{conn: conn} do
+      today = Timex.today()
+
+      kimu = insert(:contest, allows_registration: false, round: 0, deadline: today)
+      rw = insert(:contest, allows_registration: false, round: 1, deadline: today)
+      lw = insert(:contest, allows_registration: false, round: 2, deadline: today)
+
       conn = get(conn, Routes.page_path(conn, :registration))
 
+      refute html_response(conn, 200) =~ ContestView.name_with_flag(kimu)
+      refute html_response(conn, 200) =~ ContestView.name_with_flag(rw)
       refute html_response(conn, 200) =~ ContestView.name_with_flag(lw)
     end
   end

--- a/test/jumubase_web/views/performance_view_test.exs
+++ b/test/jumubase_web/views/performance_view_test.exs
@@ -1,0 +1,23 @@
+defmodule JumubaseWeb.PerformanceViewTest do
+  use JumubaseWeb.ConnCase, async: true
+  alias JumubaseWeb.PerformanceView
+
+  describe "predecessor_host_options/1" do
+    test "returns formatted host options for a given LW contest, ordered by name" do
+      # Matching hosts
+      h1 = insert(:host, name: "B", current_grouping: "1")
+      h2 = insert(:host, name: "A", current_grouping: "1")
+
+      # Non-matching host
+      insert(:host, current_grouping: "2")
+
+      c = insert(:contest, host: h1, round: 2)
+      assert PerformanceView.predecessor_host_options(c) == [{h2.name, h2.id}, {h1.name, h1.id}]
+    end
+
+    test "returns an empty list for a given RW contest" do
+      c = insert(:contest, round: 1)
+      assert PerformanceView.predecessor_host_options(c) == []
+    end
+  end
+end


### PR DESCRIPTION
This allows users to register for certain LW contests via the registration form. This is needed for groupings 1 and 3, whose RW contests are not (yet…?) part of the system.

We ensure on the schema level that a performance's `predecessor_host_id` can only be changed if there is no pre-existing predecessor info attached to the performance. This prevents data inconsistencies caused by changing the predecessor host of a previously migrated LW performance, which also has an associated `predecessor` and `predecessor_contest`.

The `Seeder` has been updated to allow registration _for all contests except LWs in grouping 2_ by default. This can be changed by admins in the contests listing later.